### PR TITLE
Add Cloud Spanner driver and dialect versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
                 <artifactId>cloud-spanner-r2dbc</artifactId>
                 <version>${r2dbc-cloud-spanner.version}</version>
             </dependency>
-            <dependency>
-                <groupId>com.google.cloud</groupId>
-                <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
-                <version>${r2dbc-cloud-spanner.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <r2dbc-pool.version>0.9.0.BUILD-SNAPSHOT</r2dbc-pool.version>
         <r2dbc-proxy.version>0.9.0.BUILD-SNAPSHOT</r2dbc-proxy.version>
         <r2dbc-spi.version>0.9.0.BUILD-SNAPSHOT</r2dbc-spi.version>
+        <r2dbc-cloud-spanner.version>0.2.0</r2dbc-cloud-spanner.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -99,6 +100,16 @@
                 <groupId>io.r2dbc</groupId>
                 <artifactId>r2dbc-spi</artifactId>
                 <version>${r2dbc-spi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>cloud-spanner-r2dbc</artifactId>
+                <version>${r2dbc-cloud-spanner.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>cloud-spanner-spring-data-r2dbc</artifactId>
+                <version>${r2dbc-cloud-spanner.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
I've added both, the driver and the dialect.

Since all other dialects are part of _Spring Data R2DBC_, Cloud Spanner dialect is the only one in the BOM and so sticks out a bit, but there is no other logical place to specify its version.

I'll send a separate PR for `0.8.x` branch if this change looks reasonable.